### PR TITLE
Change "Orientation" event to "Button Orientation"

### DIFF
--- a/Samples/AzureIoT/main.c
+++ b/Samples/AzureIoT/main.c
@@ -587,6 +587,6 @@ static void SendOrientationButtonHandler(void)
 {
     if (IsButtonPressed(sendOrientationButtonGpioFd, &sendOrientationButtonState)) {
         deviceIsUp = !deviceIsUp;
-        SendTelemetry("Orientation", deviceIsUp ? "Up" : "Down");
+        SendTelemetry("Button Orientation", deviceIsUp ? "Up" : "Down");
     }
 }


### PR DESCRIPTION
I changed the SendTelemetry for the button orientation to send "Button Orientation" instead of "Orientation". This will be less confusing for people who will assume "Orientation" might be related to the device orientation or possible gyroscope sensor in the device. "Button Orientation" is more descriptive of what event is actually being reported. :)