### PR TITLE
Removed unnecessary function call.

### DIFF
--- a/Samples/IntercoreComms/IntercoreComms_HighLevelApp/main.c
+++ b/Samples/IntercoreComms/IntercoreComms_HighLevelApp/main.c
@@ -129,7 +129,6 @@ static int InitHandlers(void)
     if (timerFd < 0) {
         return -1;
     }
-    RegisterEventHandlerToEpoll(epollFd, timerFd, &timerEventData, EPOLLIN);
 
     // Open connection to real-time capable application.
     sockFd = Application_Socket(rtAppComponentId);


### PR DESCRIPTION
RegisterEventHandlerToEpoll() is invoked inside the preceding call to CreateTimerFdAndAddToEpoll() rendering this call superfluous.