### PR TITLE
fix StatusLED

### DIFF
--- a/Samples/AzureIoT/app_manifest.json
+++ b/Samples/AzureIoT/app_manifest.json
@@ -6,7 +6,7 @@
   "CmdArgs": [],
   "Capabilities": {
     "AllowedConnections": [ "global.azure-devices-provisioning.net" ],
-    "Gpio": [ "$SAMPLE_BUTTON_1", "$SAMPLE_LED" ],
+    "Gpio": [ "$SAMPLE_BUTTON_1", "$MT3620_RDB_STATUS_LED_GREEN" ],
     "DeviceAuthentication": "00000000-0000-0000-0000-000000000000"
   },
     "ApplicationType": "Default"

--- a/Samples/AzureIoT/main.c
+++ b/Samples/AzureIoT/main.c
@@ -260,11 +260,11 @@ static ExitCode InitPeripheralsAndHandlers(void)
     }
 
     // SAMPLE_LED is used to show Device Twin settings state
-    Log_Debug("Opening SAMPLE_LED as output.\n");
+    Log_Debug("Opening MT3620_RDB_STATUS_LED_GREEN as output.\n");
     deviceTwinStatusLedGpioFd =
-        GPIO_OpenAsOutput(SAMPLE_LED, GPIO_OutputMode_PushPull, GPIO_Value_High);
+        GPIO_OpenAsOutput(MT3620_RDB_STATUS_LED_GREEN, GPIO_OutputMode_PushPull, GPIO_Value_High);
     if (deviceTwinStatusLedGpioFd == -1) {
-        Log_Debug("ERROR: Could not open SAMPLE_LED: %s (%d).\n", strerror(errno), errno);
+        Log_Debug("ERROR: Could not open MT3620_RDB_STATUS_LED_GREEN: %s (%d).\n", strerror(errno), errno);
         return ExitCode_Init_TwinStatusLed;
     }
 
@@ -461,10 +461,10 @@ static void DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
     }
 
     // The desired properties should have a "StatusLED" object
-    JSON_Object *LEDState = json_object_dotget_object(desiredProperties, "StatusLED");
-    if (LEDState != NULL) {
+    JSON_Value *LEDState = json_object_dotget_value(desiredProperties, "StatusLED");
+    if (NULL != LEDState) {
         // ... with a "value" field which is a Boolean
-        int statusLedValue = json_object_get_boolean(LEDState, "value");
+        int statusLedValue = json_value_get_boolean(LEDState);
         if (statusLedValue != -1) {
             statusLedOn = statusLedValue == 1;
             GPIO_SetValue(deviceTwinStatusLedGpioFd,


### PR DESCRIPTION
StatusLED doesn't seem working. 
two issues: 
1) in app_manifest.json Capabilities/GPIO: mismatched pin (for example, should $MT3620_RDB_STATUS_LED_GREEN,...)
in DeviceTwinCallback: 
2) the below always returns NULL as the StatusLED is not JSON_Object but JSON_Value
    JSON_Object *LEDState = json_object_dotget_object(desiredProperties, "StatusLED");

The below fixes and syncs the StatusLED:
    JSON_Value *LEDState = json_object_dotget_value(desiredProperties, "StatusLED");
    if (NULL != LEDState) {
        // ... with a "value" field which is a Boolean
        int statusLedValue = json_value_get_boolean(LEDState);
        if (statusLedValue != -1) {
            statusLedOn = statusLedValue == 1;
            GPIO_SetValue(deviceTwinStatusLedGpioFd,
                          statusLedOn ? GPIO_Value_Low : GPIO_Value_High);
        }
    }
