### PR TITLE
Fixed telemetry type in Azure IoT Sample

### DIFF
--- a/Samples/AzureIoT/main.c
+++ b/Samples/AzureIoT/main.c
@@ -292,7 +292,7 @@ static void ButtonPollTimerEventHandler(EventLoopTimer *timer)
     }
 
     if (IsButtonPressed(sendMessageButtonGpioFd, &sendMessageButtonState)) {
-        SendTelemetry("{\"ButtonPress\" : \"True\"}");
+        SendTelemetry("{\"ButtonPress\" : true}");
     }
 }
 


### PR DESCRIPTION
The Azure IoT Central capability model expects a boolean for the telemetry ButtonPress, not a string