### PR TITLE
Add auto URL encoding on IoT Hub Client to the DAA IoT Hub sample 

### DIFF
--- a/Samples/AzureIoT/IoTHub/connection_iot_hub.c
+++ b/Samples/AzureIoT/IoTHub/connection_iot_hub.c
@@ -135,6 +135,15 @@ static bool SetUpAzureIoTHubClientWithDaa(void)
         goto cleanup;
     }
 
+    // Sets auto URL encoding on IoT Hub Client
+    bool urlAutoEncodeDecode = true;
+    if (IoTHubDeviceClient_LL_SetOption(iothubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE,
+                                        &urlAutoEncodeDecode) != IOTHUB_CLIENT_OK) {
+        Log_Debug("ERROR: Failed to set auto Url encode option on IoT Hub Client\n");
+        return false;
+        goto cleanup;
+    }
+
     // Sets model ID on IoT Hub Client
     if ((iothubResult = IoTHubDeviceClient_LL_SetOption(iothubClientHandle, OPTION_MODEL_ID,
                                                         azureSphereModelId)) != IOTHUB_CLIENT_OK) {

--- a/Samples/AzureIoT/IoTHub/connection_iot_hub.c
+++ b/Samples/AzureIoT/IoTHub/connection_iot_hub.c
@@ -137,10 +137,11 @@ static bool SetUpAzureIoTHubClientWithDaa(void)
 
     // Sets auto URL encoding on IoT Hub Client
     bool urlAutoEncodeDecode = true;
-    if (IoTHubDeviceClient_LL_SetOption(iothubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE,
-                                        &urlAutoEncodeDecode) != IOTHUB_CLIENT_OK) {
-        Log_Debug("ERROR: Failed to set auto Url encode option on IoT Hub Client\n");
-        return false;
+    if ((iothubResult = IoTHubDeviceClient_LL_SetOption(iothubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE,
+                                        &urlAutoEncodeDecode)) != IOTHUB_CLIENT_OK) {
+        Log_Debug("ERROR: Failed to set auto Url encode option on IoT Hub Client: %s\n",
+                  IOTHUB_CLIENT_RESULTStrings(iothubResult));
+        retVal = false;
         goto cleanup;
     }
 


### PR DESCRIPTION
Added auto url encoding to support setting the content type for a message - eg "application/json"

The IoT Hub sample was missing setting “auto url encoding” – it’s done in the DPS sample.

Without url encoding when you set the content type for a message to "application/json" (or other mime type) it errors and closes the connection to IoT Hub.

Content type and encoding required for upstream Event Grid progressing.

       .contentEncoding = "utf-8",
       .contentType = "application/json"

