### PR TITLE
Fix minor clang-format violation

### DIFF
--- a/Samples/AzureIoT/IoTHub/connection_iot_hub.c
+++ b/Samples/AzureIoT/IoTHub/connection_iot_hub.c
@@ -137,8 +137,9 @@ static bool SetUpAzureIoTHubClientWithDaa(void)
 
     // Sets auto URL encoding on IoT Hub Client
     bool urlAutoEncodeDecode = true;
-    if ((iothubResult = IoTHubDeviceClient_LL_SetOption(iothubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE,
-                                        &urlAutoEncodeDecode)) != IOTHUB_CLIENT_OK) {
+    if ((iothubResult = IoTHubDeviceClient_LL_SetOption(
+             iothubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlAutoEncodeDecode)) !=
+        IOTHUB_CLIENT_OK) {
         Log_Debug("ERROR: Failed to set auto Url encode option on IoT Hub Client: %s\n",
                   IOTHUB_CLIENT_RESULTStrings(iothubResult));
         retVal = false;


### PR DESCRIPTION
Prior commit had a minor style violation; clang-format fix applied.