### PR TITLE
Add support for event creation timestamps to Azure IoT sample

### DIFF
--- a/Samples/AzureIoT/README.md
+++ b/Samples/AzureIoT/README.md
@@ -29,8 +29,8 @@ This sample demonstrates how to use the Azure IoT SDK C APIs in an Azure Sphere 
 
 This sample application implements an example *thermometer* that works with Azure IoT Hub as follows:
 
-1. Sends simulated *temperature* telemetry data at regular intervals.
-1. Sends a simulated *thermometer moved* telemetry event when button B is pressed.
+1. Sends simulated *temperature* telemetry data at regular intervals, with a timestamp.
+1. Sends a simulated *thermometer moved* telemetry event (with timestamp) when button B is pressed.
 1. Reports a read-only string *serial number* device twin.
 1. Synchronizes a read/write boolean *Thermometer Telemetry Upload Enabled* device twin.
    - This status is reflected by one of the LEDs on the MT3620 development board.

--- a/Samples/AzureIoT/READMEStartWithIoTHub.md
+++ b/Samples/AzureIoT/READMEStartWithIoTHub.md
@@ -75,12 +75,12 @@ View and edit the device twin:
 
 1. In the *properties* field, under **reported**, note that the device has reported its serial number.
 
-1. In the *properties* field, under **desired**, add `"ThermometerTelemetryUploadEnabled": true,` as shown below:
+1. In the *properties* field, under **desired**, add `"thermometerTelemetryUploadEnabled": true,` as shown below:
 
    ```json
       "properties": {
          "desired": {
-            "ThermometerTelemetryUploadEnabled": true,
+            "thermometerTelemetryUploadEnabled": true,
             "$metadata": {
             "$lastUpdated": "2019-01-30T22:18:19.612025Z",
    ```
@@ -117,11 +117,11 @@ You can view telemetry:
 
 ## Step 6. Note how the app uses Azure IoT PnP
 
-The application implements an example [Azure IoT Plug and Play (PnP)](https://docs.microsoft.com/azure/iot-pnp/) model called "Azure Sphere example".  It sends this model's ID when it connects to Azure IoT Hub.
+The application implements an example [Azure IoT Plug and Play (PnP)](https://docs.microsoft.com/azure/iot-pnp/) model called "Azure Sphere Example Thermometer".  It sends this model's ID when it connects to Azure IoT Hub.
 
 Follow the [IoT Explorer instructions](https://docs.microsoft.com/azure/iot-pnp/howto-use-iot-explorer) to interact and test this feature.
 
-Note how the Azure IoT Explorer client finds and uses the PnP model to understand the device's data, and you don't need to type the model's parameter names, like ThermometerTelemetryUploadEnabled or DisplayAlert.
+Note how the Azure IoT Explorer client finds and uses the PnP model to understand the device's data, and you don't need to type the model's parameter names, like thermometerTelemetryUploadEnabled or displayAlert.
 
 ## Next steps
 

--- a/Samples/AzureIoT/common/azure_iot.c
+++ b/Samples/AzureIoT/common/azure_iot.c
@@ -289,7 +289,8 @@ static void DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
     }
 }
 
-AzureIoT_Result AzureIoT_SendTelemetry(const char *jsonMessage, void *context)
+AzureIoT_Result AzureIoT_SendTelemetry(const char *jsonMessage, const char *iso8601DateTimeString,
+                                       void *context)
 {
     Log_Debug("Sending Azure IoT Hub telemetry: %s.\n", jsonMessage);
 
@@ -309,6 +310,10 @@ AzureIoT_Result AzureIoT_SendTelemetry(const char *jsonMessage, void *context)
     if (messageHandle == 0) {
         Log_Debug("ERROR: unable to create a new IoTHubMessage.\n");
         return AzureIoT_Result_OtherFailure;
+    }
+
+    if (iso8601DateTimeString != NULL) {
+        IoTHubMessage_SetProperty(messageHandle, "iothub-creation-time-utc", iso8601DateTimeString);
     }
 
     AzureIoT_Result result = AzureIoT_Result_OK;

--- a/Samples/AzureIoT/common/azure_iot.h
+++ b/Samples/AzureIoT/common/azure_iot.h
@@ -123,9 +123,14 @@ void AzureIoT_Cleanup(void);
 ///     <see cref="AzureIoT_Initialize" />) to indicate success or failure.
 /// </summary>
 /// <param name="jsonMessage">The telemetry to send, as a JSON string.</param>
+/// <param name="iso8601DateTimeString">
+///     Timestamp for the event as an ISO 8601 date/time string; if NULL, no timestamp will be
+///     included with the message.
+/// </param>
 /// <param name="context">An optional context, which will be passed to the callback.</param>
 /// <returns>An <see cref="AzureIoT_Result" /> indicating success or failure.</returns>
-AzureIoT_Result AzureIoT_SendTelemetry(const char *jsonMessage, void *context);
+AzureIoT_Result AzureIoT_SendTelemetry(const char *jsonMessage, const char *iso8601DateTimeString,
+                                       void *context);
 
 /// <summary>
 ///     Enqueue a report containing Device Twin properties to send to the Azure IoT Hub. The report

--- a/Samples/AzureIoT/common/cloud.h
+++ b/Samples/AzureIoT/common/cloud.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <time.h>
+
 #include "exitcodes.h"
 
 // This header describes a backend-agnostic interface to a cloud platform.
@@ -91,14 +93,18 @@ void Cloud_Cleanup(void);
 /// Queue sending telemtry to the cloud backend.
 /// </summary>
 /// <param name="telemetry">A pointer to a <see cref="Cloud_Telemetry" /> structure to send.</param>
+/// <param name="timestamp">
+///     Timestamp for the telemetry event, or (time_t) -1 for no timestamp.
+/// </param>
 /// <returns>A <see cref="Cloud_Result" /> indicating success or failure.</returns>
-Cloud_Result Cloud_SendTelemetry(const Cloud_Telemetry *telemetry);
+Cloud_Result Cloud_SendTelemetry(const Cloud_Telemetry *telemetry, time_t timestamp);
 
 /// <summary>
 /// Queue sending an event to the cloud indicating that the device location has changed.
 /// </summary>
+/// <param name="timestamp">Timestamp for the move event, or (time_t) -1 for no timestamp.</param>
 /// <returns>A <see cref="Cloud_Result" /> indicating success or failure.</returns>
-Cloud_Result Cloud_SendThermometerMovedEvent(void);
+Cloud_Result Cloud_SendThermometerMovedEvent(time_t timestamp);
 
 /// <summary>
 /// Queue sending device status to the cloud indicating whether telemetry upload is enabled.


### PR DESCRIPTION
Azure IoT sample: Use the "iothub-creation-time-utc" message property to set the event creation time, providing a base for store-and-forward scenarios.